### PR TITLE
smdk4412-common: Add USB ethernet support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -147,6 +147,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:system/etc/permissions/android.hardware.camera.flash-autofocus.xml \
     frameworks/native/data/etc/android.hardware.camera.front.xml:system/etc/permissions/android.hardware.camera.front.xml \
     frameworks/native/data/etc/android.hardware.camera.xml:system/etc/permissions/android.hardware.camera.xml \
+    frameworks/native/data/etc/android.hardware.ethernet.xml:system/etc/permissions/android.hardware.ethernet.xml \
     frameworks/native/data/etc/android.hardware.location.gps.xml:system/etc/permissions/android.hardware.location.gps.xml \
     frameworks/native/data/etc/android.hardware.location.xml:system/etc/permissions/android.hardware.location.xml \
     frameworks/native/data/etc/android.hardware.sensor.accelerometer.xml:system/etc/permissions/android.hardware.sensor.accelerometer.xml \

--- a/rootdir/init.smdk4x12.rc
+++ b/rootdir/init.smdk4x12.rc
@@ -521,6 +521,11 @@ service dhcpcd_bt-pan /system/bin/dhcpcd -ABKL
     disabled
     oneshot
 
+service dhcpcd_eth0 /system/bin/dhcpcd -aABDKL
+    class late_start
+    disabled
+    oneshot
+
 service iprenew_wlan0 /system/bin/dhcpcd -n
     class main
     disabled
@@ -533,6 +538,11 @@ service iprenew_p2p /system/bin/dhcpcd -n
 
 service iprenew_bt-pan /system/bin/dhcpcd -n
     class main
+    disabled
+    oneshot
+
+service iprenew_eth0 /system/bin/dhcpcd -n
+    class late_start
     disabled
     oneshot
 


### PR DESCRIPTION
Bring up device and start dhdcpcd automatically, if kernel drivers and
connection are present,

Change-Id: I5ec4d832ff3683689a96d7f054222664492f199f